### PR TITLE
Show the glyph color in the background of the layer palette

### DIFF
--- a/fontforge/charinfo.c
+++ b/fontforge/charinfo.c
@@ -1639,6 +1639,7 @@ static void CI_ApplyAll(CharInfo *ci) {
 	    GDrawRequestExpose(fvs->v,NULL,false);	/* Redraw character area in case this char is on screen */
 	}
     }
+    CVLayersRedraw();
     if ( ci->changes )
 	sf->changed = true;
 }
@@ -4183,7 +4184,7 @@ return;
     if ( enc==-1 )
 	enc = map->backmap[sc->orig_pos];
     ci->enc = enc;
-
+    
     if ( !boxset ) {
 	extern GBox _ggadget_Default_Box;
 	extern void GGadgetInit(void);

--- a/fontforge/cvpalettes.c
+++ b/fontforge/cvpalettes.c
@@ -1934,7 +1934,13 @@ return;
             r.y = y;
             r.height = layer_height;
             GDrawFillRect(pixmap,&r,mocolor);
-        }
+        } else {
+            r.x = editcol; r.width = ww-r.x;
+	    r.y = y;
+	    r.height = layer_height;
+	    GDrawFillRect(pixmap,&r,cv->b.sc->color);
+	}
+	
         r.x=editcol;
 	if ( ll==-1 || ll==0 || ll==1) {
 	    str = ll==-1 ? _("Guide") : (ll==0 ?_("Back") : _("Fore")) ;
@@ -4131,4 +4137,10 @@ void PalettesChangeDocking(void) {
 
 int BVPalettesWidth(void) {
 return( GGadgetScale(BV_LAYERS_WIDTH));
+}
+
+void CVLayersRedraw() 
+{
+    GDrawRequestExpose(cvlayers,NULL,false);
+
 }


### PR DESCRIPTION
The background in the cv palettes now shows the glyph info / comment / color for the character
